### PR TITLE
Add Dockerfiles for backend and frontend services

### DIFF
--- a/calendar-secretary/backend/Dockerfile
+++ b/calendar-secretary/backend/Dockerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim
+
+WORKDIR /app
+
+ENV POETRY_VERSION=1.7.1
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends build-essential curl && \
+    pip install "poetry==${POETRY_VERSION}" && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+COPY pyproject.toml poetry.lock ./
+
+RUN poetry config virtualenvs.create false && \
+    poetry install --no-interaction --no-ansi --only main
+
+COPY app ./app
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/calendar-secretary/frontend/Dockerfile
+++ b/calendar-secretary/frontend/Dockerfile
@@ -1,0 +1,13 @@
+# syntax=docker/dockerfile:1
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json ./
+RUN npm install
+
+COPY . .
+
+EXPOSE 5173
+
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]


### PR DESCRIPTION
## Summary
- add a backend Dockerfile that installs Poetry dependencies and runs the FastAPI app with uvicorn
- add a frontend Dockerfile based on Node 20 that installs npm dependencies and runs the Vite dev server

## Testing
- `docker compose up --build --no-start` *(fails: docker not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1a0af6148832ea2ea9c7fab14b32c