### PR TITLE
Update Dockerfiles for backend and frontend builds

### DIFF
--- a/calendar-secretary/backend/Dockerfile
+++ b/calendar-secretary/backend/Dockerfile
@@ -3,17 +3,23 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-ENV POETRY_VERSION=1.7.1
+ENV POETRY_VERSION=1.7.1 \
+    POETRY_HOME="/opt/poetry" \
+    POETRY_VIRTUALENVS_CREATE=false \
+    POETRY_NO_INTERACTION=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+ENV PATH="$POETRY_HOME/bin:$PATH"
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends build-essential curl && \
-    pip install "poetry==${POETRY_VERSION}" && \
+    curl -sSL https://install.python-poetry.org | python - --version ${POETRY_VERSION} && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY pyproject.toml poetry.lock ./
 
-RUN poetry config virtualenvs.create false && \
-    poetry install --no-interaction --no-ansi --only main
+RUN poetry install --only main --no-ansi
 
 COPY app ./app
 

--- a/calendar-secretary/frontend/Dockerfile
+++ b/calendar-secretary/frontend/Dockerfile
@@ -3,7 +3,8 @@ FROM node:20-alpine
 
 WORKDIR /app
 
-COPY package.json ./
+COPY package*.json ./
+
 RUN npm install
 
 COPY . .


### PR DESCRIPTION
## Summary
- refresh the backend Dockerfile to configure Poetry via the official installer and set runtime-friendly environment variables
- streamline the frontend Dockerfile so dependency manifests are copied prior to installing packages

## Testing
- not run (docker is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e213d92d78832e8e457c73ebd39013