### PR TITLE
Rename event metadata attribute

### DIFF
--- a/calendar-secretary/backend/app/models/event.py
+++ b/calendar-secretary/backend/app/models/event.py
@@ -31,7 +31,7 @@ class Event(Base):
     calendar_id = Column(String, nullable=True)
     external_ids = Column(JSON, nullable=True)
     constraints = Column(JSON, nullable=True)
-    metadata = Column(JSON, nullable=True)
+    metadata_json = Column("metadata", JSON, nullable=True)
     family_key = Column(String, nullable=True)
     pomodoro_opt_in = Column(Boolean, default=False, nullable=False)
 

--- a/calendar-secretary/backend/app/schemas/event.py
+++ b/calendar-secretary/backend/app/schemas/event.py
@@ -53,7 +53,7 @@ class EventBase(BaseModel):
     calendar_id: str | None = None
     external_ids: dict[str, str | None] | None = None
     constraints: ConstraintOptions | None = None
-    metadata: MetadataOptions | None = None
+    metadata_json: MetadataOptions | None = Field(default=None, alias="metadata")
     family_key: str | None = None
     pomodoro_opt_in: bool = False
     depends_on: list[DependencyRef] = Field(default_factory=list)
@@ -64,6 +64,9 @@ class EventBase(BaseModel):
         if not 1 <= value <= 10:
             raise ValueError("priority must be between 1 and 10")
         return value
+
+    class Config:
+        allow_population_by_field_name = True
 
 
 class EventCreate(EventBase):
@@ -81,3 +84,4 @@ class EventSchema(EventBase):
 
     class Config:
         orm_mode = True
+        allow_population_by_field_name = True

--- a/calendar-secretary/backend/app/schemas/plan.py
+++ b/calendar-secretary/backend/app/schemas/plan.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Any
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class ScheduledChunk(BaseModel):
@@ -13,7 +13,10 @@ class ScheduledChunk(BaseModel):
     start: datetime
     end: datetime
     is_break: bool = False
-    metadata: dict[str, Any] | None = None
+    metadata_json: dict[str, Any] | None = Field(default=None, alias="metadata")
+
+    class Config:
+        allow_population_by_field_name = True
 
 
 class PlanSolution(BaseModel):


### PR DESCRIPTION
## Summary
- rename the SQLAlchemy `Event` metadata attribute to `metadata_json` while keeping the column name `metadata`
- update event and plan Pydantic schemas to expose the renamed field via an alias so external APIs remain unchanged

## Testing
- ⚠️ `docker compose build backend` *(fails: `docker` is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e21d078170832e91bd08006f7b7d23