### PR TITLE
Preserve frontend dependencies in compose setup

### DIFF
--- a/calendar-secretary/docker-compose.yml
+++ b/calendar-secretary/docker-compose.yml
@@ -25,6 +25,10 @@ services:
       - "5173:5173"
     command: npm run dev -- --host 0.0.0.0
     volumes:
-      - ./frontend:/app
+      - ./frontend:/app:delegated
+      - frontend_node_modules:/app/node_modules
     depends_on:
       - backend
+
+volumes:
+  frontend_node_modules:


### PR DESCRIPTION
## Summary
- adjust the frontend service volume mounts to avoid overwriting installed dependencies
- add a dedicated named volume for frontend node_modules so builds persist across restarts

## Testing
- docker compose up --build *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e21fcd744c832ea95f2e79c681d188