### PR TITLE
Fix event serialization and planner dependency handling

### DIFF
--- a/calendar-secretary/backend/app/services/planner/heuristic_solver.py
+++ b/calendar-secretary/backend/app/services/planner/heuristic_solver.py
@@ -6,6 +6,7 @@ from typing import Iterable
 from uuid import uuid4
 
 from app.schemas.plan import PlanSolution, ProposalResponse, ScheduledChunk
+from app.services.planner.rules import topological_sort
 
 
 @dataclass
@@ -24,13 +25,66 @@ class HeuristicPlanner:
        total tardiness.
     """
 
+    def _extract_dependency_ids(self, event: any) -> set[str]:
+        dependency_ids: set[str] = set()
+        raw_dependencies = getattr(event, "depends_on", None)
+        if raw_dependencies:
+            for dependency in raw_dependencies:
+                if isinstance(dependency, dict):
+                    dep_id = dependency.get("task_id") or dependency.get("depends_on_id")
+                else:
+                    dep_id = getattr(dependency, "task_id", None)
+                    if dep_id is None:
+                        dep_id = getattr(dependency, "depends_on_id", None)
+                if dep_id is not None:
+                    dependency_ids.add(str(dep_id))
+        orm_dependencies = getattr(event, "dependencies", None)
+        if orm_dependencies:
+            for dependency in orm_dependencies:
+                dep_id = getattr(dependency, "depends_on_id", None)
+                if dep_id is not None:
+                    dependency_ids.add(str(dep_id))
+        return dependency_ids
+
     def _sort_events(self, events: Iterable, families: dict[str, any]) -> list[HeuristicTask]:
-        tasks: list[HeuristicTask] = []
-        for event in events:
+        event_map = {str(event.id): event for event in events}
+        tasks: dict[str, HeuristicTask] = {}
+        prerequisite_map: dict[str, set[str]] = {}
+        adjacency: dict[str, set[str]] = {event_id: set() for event_id in event_map}
+
+        for event_id, event in event_map.items():
             family = families.get(event.family_key)
             weight = family.weight if family else 1.0
-            tasks.append(HeuristicTask(event=event, priority=event.priority * weight))
-        return sorted(tasks, key=lambda item: item.priority, reverse=True)
+            tasks[event_id] = HeuristicTask(event=event, priority=event.priority * weight)
+            dependencies = {
+                dep_id
+                for dep_id in self._extract_dependency_ids(event)
+                if dep_id in event_map and dep_id != event_id
+            }
+            prerequisite_map[event_id] = dependencies
+            for dep_id in dependencies:
+                adjacency.setdefault(dep_id, set()).add(event_id)
+
+        if not tasks:
+            return []
+
+        topo_order = topological_sort(tasks.keys(), adjacency)
+        topo_index = {event_id: index for index, event_id in enumerate(topo_order)}
+
+        indegree = {event_id: len(prerequisite_map[event_id]) for event_id in tasks}
+        available = [event_id for event_id, degree in indegree.items() if degree == 0]
+        ordered_tasks: list[HeuristicTask] = []
+
+        while available:
+            available.sort(key=lambda eid: (-tasks[eid].priority, topo_index[eid]))
+            current_id = available.pop(0)
+            ordered_tasks.append(tasks[current_id])
+            for child_id in adjacency.get(current_id, set()):
+                indegree[child_id] -= 1
+                if indegree[child_id] == 0:
+                    available.append(child_id)
+
+        return ordered_tasks
 
     def solve(self, events, families, pomodoro, start: datetime, end: datetime) -> PlanSolution:
         tasks = self._sort_events(events, families)

--- a/calendar-secretary/backend/app/tests/test_cp_sat_solver.py
+++ b/calendar-secretary/backend/app/tests/test_cp_sat_solver.py
@@ -1,0 +1,33 @@
+from datetime import datetime, timedelta
+from uuid import uuid4
+
+from app.services.planner.cp_sat_solver import CPSATSolver
+
+
+class DummyEvent:
+    def __init__(self, duration_min: int, priority: int):
+        self.id = uuid4()
+        self.duration_min = duration_min
+        self.priority = priority
+        self.type = "flexible"
+        self.time_windows = []
+
+
+def test_solver_prioritises_high_weight_when_time_limited():
+    solver = CPSATSolver()
+    start = datetime.utcnow()
+    end = start + timedelta(hours=1)
+    low_priority = DummyEvent(60, priority=1)
+    high_priority = DummyEvent(60, priority=10)
+
+    solution = solver.solve(
+        [low_priority, high_priority],
+        families={},
+        pomodoro=None,
+        start=start,
+        end=end,
+    )
+
+    assert solution is not None
+    assert len(solution.scheduled) == 1
+    assert str(solution.scheduled[0].event_id) == str(high_priority.id)

--- a/calendar-secretary/backend/app/tests/test_dependencies_fs.py
+++ b/calendar-secretary/backend/app/tests/test_dependencies_fs.py
@@ -5,10 +5,15 @@ from app.services.planner.heuristic_solver import HeuristicPlanner
 
 
 class DummyEvent:
-    def __init__(self, duration_min: int, depends_on: list | None = None):
+    def __init__(
+        self,
+        duration_min: int,
+        depends_on: list | None = None,
+        priority: int = 5,
+    ):
         self.id = uuid4()
         self.duration_min = duration_min
-        self.priority = 5
+        self.priority = priority
         self.family_key = None
         self.depends_on = depends_on or []
 
@@ -18,5 +23,13 @@ def test_fs_dependency_greedy_order():
     b = DummyEvent(120, depends_on=[{"task_id": str(a.id), "type": "FS", "lag_min": 30}])
     solver = HeuristicPlanner()
     plan = solver.solve([a, b], {}, None, datetime.utcnow(), datetime.utcnow() + timedelta(hours=6))
-    assert plan.scheduled[0].event_id == str(a.id)
-    assert plan.scheduled[1].event_id == str(b.id)
+    assert str(plan.scheduled[0].event_id) == str(a.id)
+    assert str(plan.scheduled[1].event_id) == str(b.id)
+
+
+def test_dependency_respected_despite_higher_priority():
+    a = DummyEvent(60, priority=3)
+    b = DummyEvent(60, depends_on=[{"task_id": str(a.id)}], priority=9)
+    solver = HeuristicPlanner()
+    plan = solver.solve([b, a], {}, None, datetime.utcnow(), datetime.utcnow() + timedelta(hours=6))
+    assert [str(chunk.event_id) for chunk in plan.scheduled[:2]] == [str(a.id), str(b.id)]

--- a/calendar-secretary/backend/app/tests/test_events_api.py
+++ b/calendar-secretary/backend/app/tests/test_events_api.py
@@ -1,0 +1,91 @@
+from datetime import datetime, timedelta
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.core import db as db_module
+from app.core.db import Base, get_db
+from app.main import app
+from app.models.event import Event
+from app.models.user import User
+
+
+@pytest.fixture()
+def client():
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        future=True,
+    )
+    TestingSessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False, future=True)
+
+    db_module.engine = engine
+    db_module.SessionLocal = TestingSessionLocal
+
+    Base.metadata.create_all(bind=engine)
+
+    with TestingSessionLocal() as session:
+        session.add(
+            User(
+                id=uuid4(),
+                email="user@example.com",
+                hashed_password="secret",
+            )
+        )
+        session.commit()
+
+    def override_get_db():
+        database = TestingSessionLocal()
+        try:
+            yield database
+        finally:
+            database.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app) as test_client:
+        yield test_client
+    app.dependency_overrides.clear()
+
+
+def test_create_event_with_time_window_persists(client):
+    start = datetime.utcnow()
+    end = start + timedelta(hours=1)
+
+    payload = {
+        "title": "Interview",
+        "type": "flexible",
+        "duration_min": 60,
+        "priority": 5,
+        "deadline": None,
+        "time_windows": [
+            {
+                "start": start.isoformat(),
+                "end": end.isoformat(),
+            }
+        ],
+        "flex": None,
+        "location": None,
+        "travel_time_min": 0,
+        "calendar_id": None,
+        "external_ids": None,
+        "constraints": None,
+        "metadata": None,
+        "family_key": None,
+        "pomodoro_opt_in": False,
+        "depends_on": [],
+    }
+
+    response = client.post("/api/events", json=payload)
+    assert response.status_code == 201
+
+    data = response.json()
+    assert data["time_windows"][0]["start"].startswith(start.isoformat(timespec="seconds"))
+
+    with db_module.SessionLocal() as session:
+        event = session.query(Event).one()
+        assert event.time_windows[0]["start"].startswith(start.isoformat())

--- a/calendar-secretary/backend/app/tests/test_family_targets.py
+++ b/calendar-secretary/backend/app/tests/test_family_targets.py
@@ -24,4 +24,4 @@ def test_family_weight_affects_order():
     ]
     solver = HeuristicPlanner()
     plan = solver.solve(events, families, None, datetime.utcnow(), datetime.utcnow() + timedelta(hours=4))
-    assert plan.scheduled[0].event_id == str(events[0].id)
+    assert str(plan.scheduled[0].event_id) == str(events[0].id)

--- a/calendar-secretary/backend/app/tests/test_planner_basic.py
+++ b/calendar-secretary/backend/app/tests/test_planner_basic.py
@@ -18,4 +18,4 @@ def test_heuristic_orders_by_priority():
     events = [DummyEvent(60, priority=p) for p in (1, 10, 5)]
     plan = solver.solve(events, {}, None, datetime.utcnow(), datetime.utcnow() + timedelta(hours=5))
     assert isinstance(plan, PlanSolution)
-    assert plan.scheduled[0].event_id in {str(events[1].id)}
+    assert str(plan.scheduled[0].event_id) in {str(events[1].id)}

--- a/calendar-secretary/backend/app/tests/test_pomodoro_splitting.py
+++ b/calendar-secretary/backend/app/tests/test_pomodoro_splitting.py
@@ -20,4 +20,4 @@ def test_pomodoro_flag_is_acknowledged():
     event = DummyEvent(180, pomodoro_opt_in=True)
     solver = HeuristicPlanner()
     plan = solver.solve([event], {}, settings, datetime.utcnow(), datetime.utcnow() + timedelta(hours=6))
-    assert plan.scheduled[0].event_id == str(event.id)
+    assert str(plan.scheduled[0].event_id) == str(event.id)


### PR DESCRIPTION
## Summary
- serialize event payloads before persisting so JSON fields like time_windows survive database writes
- tie CP-SAT objective to optional interval presence literals and drop unscheduled chunks from the solution
- respect task dependencies in the heuristic planner ordering and cover the behaviours with new regression tests
- add an API test for event creation with time windows and a solver test for priority selection under limited time

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2cd5ec130832eae709b7761ee148e