### PR TITLE
Add Docker ignore files to Docker build contexts

### DIFF
--- a/calendar-secretary/backend/.dockerignore
+++ b/calendar-secretary/backend/.dockerignore
@@ -1,0 +1,13 @@
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.env
+.venv
+.poetry
+dist
+build
+.DS_Store
+.git
+.gitignore
+

--- a/calendar-secretary/frontend/.dockerignore
+++ b/calendar-secretary/frontend/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+npm-debug.log
+dist
+.vscode
+.git
+.gitignore
+.DS_Store
+


### PR DESCRIPTION
## Summary
- add Docker ignore configuration for the frontend image to exclude node_modules and other local artifacts from the build context
- add Docker ignore configuration for the backend image to omit virtual environments and build outputs from Docker builds, keeping layers clean

## Testing
- not run (Docker is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e2d46bba1c832e84d746a7550e985c