### PR TITLE
Improve local dev startup reliability

### DIFF
--- a/calendar-secretary/backend/app/main.py
+++ b/calendar-secretary/backend/app/main.py
@@ -1,9 +1,20 @@
+import logging
+import time
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from sqlalchemy.exc import OperationalError
 
 from app.api import events, plan, sync
 from app.api import families, pomodoro
 from app.core.config import settings
+from app.core import db as db_module
+from app.models.user import User
+
+logger = logging.getLogger(__name__)
+
+RETRY_ATTEMPTS = 10
+RETRY_SLEEP_SECONDS = 1.0
 
 app = FastAPI(title="Calendar Secretary", version="0.1.0")
 
@@ -20,6 +31,45 @@ app.include_router(families.router, prefix="/api/families", tags=["families"])
 app.include_router(plan.router, prefix="/api/plan", tags=["plan"])
 app.include_router(sync.router, prefix="/api/sync", tags=["sync"])
 app.include_router(pomodoro.router, prefix="/api/users", tags=["pomodoro"])
+
+
+def _ensure_default_user() -> None:
+    with db_module.SessionLocal() as session:
+        if session.query(User).first() is None:
+            session.add(
+                User(
+                    email="demo@example.com",
+                    hashed_password="demo",  # Placeholder for demo environments
+                )
+            )
+            session.commit()
+
+
+def _initialise_database() -> None:
+    for attempt in range(1, RETRY_ATTEMPTS + 1):
+        try:
+            db_module.Base.metadata.create_all(bind=db_module.engine)
+            _ensure_default_user()
+            if attempt > 1:
+                logger.info("Connected to database after %s attempts", attempt)
+            return
+        except OperationalError as exc:  # pragma: no cover - startup safety net
+            if attempt == RETRY_ATTEMPTS:
+                logger.error("Database initialisation failed: %s", exc)
+                raise
+            logger.warning("Database not ready (attempt %s/%s): %s", attempt, RETRY_ATTEMPTS, exc)
+            time.sleep(RETRY_SLEEP_SECONDS)
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    _initialise_database()
+
+
+@app.get("/", tags=["meta"])
+async def root() -> dict[str, str]:
+    """Landing endpoint for quick manual checks."""
+    return {"status": "ok", "docs": "/docs", "health": "/health"}
 
 
 @app.get("/health", tags=["meta"])

--- a/calendar-secretary/docker-compose.yml
+++ b/calendar-secretary/docker-compose.yml
@@ -24,6 +24,8 @@ services:
     ports:
       - "5173:5173"
     command: npm run dev -- --host 0.0.0.0
+    environment:
+      VITE_BACKEND_URL: http://backend:8000
     volumes:
       - ./frontend:/app:delegated
       - frontend_node_modules:/app/node_modules

--- a/calendar-secretary/frontend/vite.config.ts
+++ b/calendar-secretary/frontend/vite.config.ts
@@ -1,9 +1,25 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    port: 5173,
-  },
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  const backendUrl = env.VITE_BACKEND_URL || "http://localhost:8000";
+
+  return {
+    plugins: [react()],
+    server: {
+      host: "0.0.0.0",
+      port: 5173,
+      proxy: {
+        "/api": {
+          target: backendUrl,
+          changeOrigin: true,
+        },
+        "/health": {
+          target: backendUrl,
+          changeOrigin: true,
+        },
+      },
+    },
+  };
 });


### PR DESCRIPTION
## Summary
- ensure the FastAPI app initialises the database with retries and seeds a demo user on startup, while exposing a root metadata endpoint
- configure the Vite dev server to proxy API and health requests to the backend and allow overriding the backend URL
- provide the frontend container with the backend URL so API calls succeed when running through docker-compose

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2d5f4164c832eb7f722713401a9d8